### PR TITLE
Switch to snap Go instead of apt package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,9 +56,10 @@ parts:
     source: https://github.com/grafana/agent
     source-type: git
     source-tag: "v0.33.1"
+    build-snaps:
+      - go
     build-packages:
       - build-essential
-      - golang
       - libsystemd-dev
       - libbpfcc-dev
       - bpfcc-tools
@@ -71,5 +72,5 @@ parts:
       - GOFLAGS: "-mod=readonly"
     override-build: |
       make agent agentctl
-      cp build/agent $CRAFT_PART_INSTALL/
-      cp build/agentctl $CRAFT_PART_INSTALL/
+      cp build/grafana-agent $CRAFT_PART_INSTALL/agent
+      cp build/grafana-agentctl $CRAFT_PART_INSTALL/agentctl


### PR DESCRIPTION
Apt Golang only supports version 1.18 and grafana 0.33.1 and above requires at least version 1.19. Fix it by switching to snap Go. 
Fix copying of builded binaries as names changed from agent to grafana-agent and agentctl to grafana-agentctl. This was changed in [commit#cbbf28](https://github.com/grafana/agent/commit/cbbf287e4183e2dcce024027a040857ed5412369).