### PR TITLE
feat(build): bump to core24 and add s390x

### DIFF
--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -68,3 +68,6 @@ jobs:
 
       - name: Upload and Publish ppc64el Snap
         run: snapcraft upload --release ${{ matrix.channel }} grafana-agent_*_ppc64el.snap
+
+      - name: Upload and Publish s390x Snap
+        run: snapcraft upload --release ${{ matrix.channel }} grafana-agent_*_s390x.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ issues: https://github.com/canonical/grafana-agent-snap/issues
 source-code: https://github.com/canonical/grafana-agent-snap
 website: https://grafana.com/oss/agent/
 description: "Grafana Agent is a telemetry collector for sending metrics, \nlogs, and trace data to the opinionated Grafana observability stack.\n"
-base: core22
+base: core24
 grade: stable
 confinement: strict
 compression: lzo
@@ -46,10 +46,11 @@ apps:
       # without this, we may face this issue while reading logs in /var/log
       # https://bugs.launchpad.net/snapd/+bug/2098780
       - home
-architectures:
-  - build-on: amd64
-  - build-on: arm64
-  - build-on: ppc64el
+platforms:
+  amd64:
+  arm64:
+  ppc64el:
+  s390x:
 parts:
   wrapper:
     plugin: dump


### PR DESCRIPTION
Core22 build fails on s390x because [libbpfcc-dev pacakge missing on s390x for jammy](https://bugs.launchpad.net/ubuntu/+source/bpfcc/+bug/2127152).
It is available for noble though, and since [core24 snaps can run on ubuntu 20.04 and 22.04](https://github.com/canonical/snapcraft/issues/5823), this should be a safe change.

In tandem with:
- https://github.com/canonical/opentelemetry-collector-snap/pull/49

Addresses:
- https://github.com/canonical/grafana-agent-operator/issues/329