### PR TITLE
Retryable, parallel build

### DIFF
--- a/.github/workflows/_build_snap.yaml
+++ b/.github/workflows/_build_snap.yaml
@@ -1,0 +1,95 @@
+name: Build snap
+
+on:
+  workflow_call:
+    inputs:
+      release:
+        description: "Release to snapcraft?"
+        type: boolean
+        default: false
+    secrets:
+        SNAPCRAFT_STORE_CREDENTIALS:
+            required: true
+        LAUNCHPAD_TOKEN:
+            required: true
+
+permissions:
+  contents: write
+
+env:
+  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+  LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
+
+jobs:
+  build:
+    name: Build snap (${{ matrix.confinement }}, ${{ matrix.build-for }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        confinement: [ "strict", "classic" ]
+        runner: [ "ubuntu-latest", "Ubuntu_ARM64_4C_16G_03" ]
+        build-for: [ "amd64", "arm64", "ppc64el", "s390x" ]
+        include:
+          - confinement: "strict"
+            channel: "latest/edge"
+          - confinement: "classic"
+            channel: "0.40-classic/edge"
+
+          - runner: "ubuntu-latest"
+            build-for: amd64
+          - runner: "ubuntu-latest"
+            build-for: ppc64el
+          - runner: "ubuntu-latest"
+            build-for: s390x
+          - runner: "Ubuntu_ARM64_4C_16G_03"
+            build-for: arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.3
+        with:
+          channel: latest/stable
+
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic --channel edge snapcraft
+      
+      - if: ${{ matrix.build-for == 'ppc64el' || matrix.build-for == 's390x' }}
+        name: Configure credentials for remote-build
+        run: |
+          # Setup Launchpad credentials (only needed for remote-build)
+          mkdir -p ~/.local/share/snapcraft
+          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad
+          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "Github Actions"
+
+      - if: ${{ matrix.confinement == 'classic' }}
+        name: yq - portable yaml processor
+        uses: mikefarah/yq@v4
+      
+      - if: ${{ matrix.confinement == 'classic' }}
+        name: Convert to Classic Snap
+        run: ./make-classic.sh
+
+      - if: ${{ matrix.build-for == 'amd64' || matrix.build-for == 'arm64' }}
+        name: Build Snap (local)
+        run: snapcraft pack
+      
+      - if: ${{ matrix.build-for == 'ppc64el' || matrix.build-for == 's390x' }}
+        name: Build Snap (remote)
+        run: snapcraft remote-build --build-for=${{ matrix.build-for }} --launchpad-accept-public-upload
+      
+      - name: Store snap
+        uses: actions/upload-artifact@v4
+        with:
+          name: grafana-agent-${{ matrix.confinement }}-${{ matrix.build-for }}-snap
+          path: "*.snap"
+
+      - if: ${{ inputs.release }}
+        name: Upload and Publish Snap
+        run: snapcraft upload --release ${{ matrix.channel }} grafana-agent_*.snap

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -10,80 +10,12 @@ on:
       - main
   workflow_dispatch: {}
 
-env:
-  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-  LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
-
 jobs:
   build:
-    name: Build snap (${{ matrix.confinement }}, ${{ matrix.build-for }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        confinement: [ "strict", "classic" ]
-        runner: [ "ubuntu-latest", "Ubuntu_ARM64_4C_16G_03" ]
-        build-for: [ "amd64", "arm64", "ppc64el", "s390x" ]
-        include:
-          - confinement: "strict"
-            channel: "latest/edge"
-          - confinement: "classic"
-            channel: "0.40-classic/edge"
-
-          - runner: "ubuntu-latest"
-            build-for: amd64
-          - runner: "ubuntu-latest"
-            build-for: ppc64el
-          - runner: "ubuntu-latest"
-            build-for: s390x
-          - runner: "Ubuntu_ARM64_4C_16G_03"
-            build-for: arm64
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.3
-        with:
-          channel: latest/stable
-
-      - name: Install dependencies
-        run: |
-          sudo snap install --classic --channel edge snapcraft
-      
-      - if: ${{ matrix.build-for == 'ppc64el' || matrix.build-for == 's390x' }}
-        name: Configure credentials for remote-build
-        run: |
-          # Setup Launchpad credentials (only needed for remote-build)
-          mkdir -p ~/.local/share/snapcraft
-          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials
-          mkdir -p ~/.local/share/snapcraft/provider/launchpad
-          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/provider/launchpad/credentials
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "Github Actions"
-
-      - if: ${{ matrix.confinement == 'classic' }}
-        name: yq - portable yaml processor
-        uses: mikefarah/yq@v4
-      
-      - if: ${{ matrix.confinement == 'classic' }}
-        name: Convert to Classic Snap
-        run: ./make-classic.sh
-
-      - if: ${{ matrix.build-for == 'amd64' || matrix.build-for == 'arm64' }}
-        name: Build Snap (local)
-        run: snapcraft pack
-      
-      - if: ${{ matrix.build-for == 'ppc64el' || matrix.build-for == 's390x' }}
-        name: Build Snap (remote)
-        run: snapcraft remote-build --build-for=${{ matrix.build-for }} --launchpad-accept-public-upload
-      
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: grafana-agent-${{ matrix.confinement }}-${{ matrix.build-for }}-snap
-          path: "*.snap"
-
-      - name: Upload and Publish Snap
-        run: snapcraft upload --release ${{ matrix.channel }} grafana-agent_*.snap
-  
+    name: Build and release snaps
+    uses: canonical/grafana-agent-snap/.github/workflows/_build_snap.yaml
+    permissions:
+      contents: write
+    secrets: inherit
+    with:
+      release: true

--- a/.github/workflows/test-build-snap.yaml
+++ b/.github/workflows/test-build-snap.yaml
@@ -7,46 +7,12 @@ name: Test Build Snap
 on:
   pull_request:
 
-env:
-  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-  LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
-
 jobs:
   build:
-    name: Build snap (${{ matrix.confinement }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        confinement: [ "strict", "classic" ]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          # snapcraft remote-build requires a full clone
-          fetch-depth: 0
-
-      - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.1
-        with:
-          channel: latest/stable
-
-      - name: Install dependencies
-        run: |
-          sudo snap install --classic --channel edge snapcraft
-          # Setup Launchpad credentials
-          mkdir -p ~/.local/share/snapcraft
-          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/launchpad-credentials
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "Github Actions"
-
-      - if: ${{ matrix.confinement == 'classic' }}
-        name: yq - portable yaml processor
-        uses: mikefarah/yq@v4
-
-      - if: ${{ matrix.confinement == 'classic' }}
-        name: Convert to Classic Snap
-        run: ./make-classic.sh
-
-      - name: Build Snap (remote)
-        run: snapcraft remote-build --launchpad-accept-public-upload
+    name: Build snaps
+    uses: canonical/grafana-agent-snap/.github/workflows/_build_snap.yaml
+    permissions:
+      contents: write
+    secrets: inherit
+    with:
+      release: false


### PR DESCRIPTION
This PR modifies the workflows to build the snaps in parallel, enabling a per-arch retry.

Fixes #97.
